### PR TITLE
Add select functionality

### DIFF
--- a/airtable.html
+++ b/airtable.html
@@ -58,6 +58,7 @@
   <div class="form-row">
     <label for="node-input-operation"><i class="fa fa-wrench"></i> Operation</label>
     <select type="text" id="node-input-operation">
+      <option value="select">select</option>
       <option value="find">find</option>
       <option value="create">create</option>
       <option value="update">update</option>

--- a/airtable.js
+++ b/airtable.js
@@ -67,6 +67,10 @@ module.exports = function (RED) {
         }
         var base = new Airtable({apiKey: credentials.apiKey}).base(credentials.baseId);
         switch (node.operation) {
+          case 'select':
+            msg.payload = node.convType(msg.payload, 'object');
+            base(node.table).select(msg.payload, node.sendMsg);
+            break;
           case 'find':
             msg.payload = node.convType(msg.recId, 'string');
             base(node.table).find(msg.recId, node.sendMsg);

--- a/airtable.js
+++ b/airtable.js
@@ -68,8 +68,17 @@ module.exports = function (RED) {
         var base = new Airtable({apiKey: credentials.apiKey}).base(credentials.baseId);
         switch (node.operation) {
           case 'select':
+            let records = [];
             msg.payload = node.convType(msg.payload, 'object');
-            base(node.table).select(msg.payload, node.sendMsg);
+            base(node.table).select(msg.payload)
+              .eachPage(function page(records, fetchNextPage) {
+                records.forEach(function(record) {
+                    node.sendMsg(null, record);
+                });
+                fetchNextPage();
+              }, function done(err) {
+                  if (err) { console.error(err); return; }
+              });;
             break;
           case 'find':
             msg.payload = node.convType(msg.recId, 'string');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-airtable",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A collection of Node-RED nodes for Airtable.",
   "dependencies": {
     "airtable": "^0.5.3"
@@ -27,6 +27,10 @@
     {
       "name": "joeartsea",
       "email": "artsnet111@gmail.com"
+    },
+    {
+      "name": "deanputney",
+      "email": "dean@deanputney.com"
     }
   ]
 }


### PR DESCRIPTION
Hi! This PR enables the `select` capability of Airtable.js in NodeRed. You may pass in a payload containing any of the parameters for a `select` filtering and the node will respond with a series of records as defined by that `select`. These records are not grouped, but a user could re-group them with the `join` or `batch` modules if desired in NodeRed.