### PR TITLE
Fix bug when outputting one record at a time.

### DIFF
--- a/airtable.js
+++ b/airtable.js
@@ -88,7 +88,7 @@ module.exports = function (RED) {
                     case 'multiple':
                     for (var i = 0; i < allRecords.length; i++){
 		      msg.payload = {'id':allRecords[i].id, 'fields': allRecords[i].fields};
-                      node.send(msg);
+                      node.send(RED.util.cloneMessage(msg));
                     }
                     break;
                     case 'array':


### PR DESCRIPTION
There was an issue when the node is set to output one message per record where the same record would always be sent, the message needs to be cloned to fix this issue.

Thanks !